### PR TITLE
Fix typo in generate_keyword_labels: word[-1] -> words[-1]

### DIFF
--- a/src/temporalmapper/plotting.py
+++ b/src/temporalmapper/plotting.py
@@ -98,7 +98,7 @@ def generate_keyword_labels(word_bags, mapper, ngram_vectorizer=None, n_words=3,
         s = ""
         for word in words[:-1]:
             s += word + sep
-        s += word[-1]
+        s += words[-1]
         label_attrs[node] = s
 
     nx.set_node_attributes(mapper.graph, label_attrs, "label")


### PR DESCRIPTION
The last keyword in each cluster label was being truncated to a single character because `word[-1]` indexed the last char of the loop variable instead of `words[-1]` (the last word in the list).